### PR TITLE
make finalization configurable by environment variable

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [master, main]
   pull_request:
-    branches: [master, main]
 
 jobs:
   happy-path-hardhat:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches: [master, main]
   pull_request:
-    branches: [master, main]
 
 jobs:
   core-tests:

--- a/orchestrator/gbt/src/orchestrator.rs
+++ b/orchestrator/gbt/src/orchestrator.rs
@@ -11,11 +11,11 @@ use gravity_utils::{
     get_block_delay, get_expected_block_delay,
     get_with_retry::get_net_version_with_retry,
     types::{BatchRequestMode, GravityBridgeToolsConfig},
-    TEST_ETH_CHAIN_ID, USE_FINALIZATION,
+    TEST_ETH_CHAIN_ID,
 };
 use metrics_exporter::metrics_server;
 use orchestrator::main_loop::{
-    orchestrator_main_loop, ETH_ORACLE_LOOP_SPEED, ETH_SIGNER_LOOP_SPEED,
+    orchestrator_main_loop, ETH_ORACLE_LOOP_SPEED, ETH_SIGNER_LOOP_SPEED, USE_FINALIZATION,
 };
 
 use crate::{args::OrchestratorOpts, utils::print_relaying_explanation};
@@ -68,7 +68,7 @@ pub async fn orchestrator(
     if net_version == TEST_ETH_CHAIN_ID {
         warn!("Chain ID is equal to TEST_ETH_CHAIN_ID, assuming this is a local test net");
     }
-    if USE_FINALIZATION {
+    if *USE_FINALIZATION {
         info!(
             "Using finalization with expected minimum block delay {}",
             expected_block_delay

--- a/orchestrator/gravity_utils/src/lib.rs
+++ b/orchestrator/gravity_utils/src/lib.rs
@@ -28,7 +28,7 @@ pub const TEST_ETH_CHAIN_ID: u64 = 1337;
 pub const BLOCK_DELAY: Uint256 = u256!(96);
 pub const TEST_BLOCK_DELAY: Uint256 = u256!(0);
 
-pub const USE_FINALIZATION: bool = true;
+pub const DEFAULT_FINALIZATION: bool = true;
 pub const EXPECTED_MIN_BLOCK_DELAY: Uint256 = u256!(32);
 pub const TEST_EXPECTED_MIN_BLOCK_DELAY: Uint256 = u256!(0);
 

--- a/orchestrator/orchestrator/src/ethereum_event_watcher.rs
+++ b/orchestrator/orchestrator/src/ethereum_event_watcher.rs
@@ -14,10 +14,11 @@ use gravity_utils::{
         TransactionBatchExecutedEvent, ValsetUpdatedEvent,
     },
     web30::{client::Web3, jsonrpc::error::Web3Error},
-    USE_FINALIZATION,
 };
 use metrics_exporter::metrics_errors_counter;
 use tonic::transport::Channel;
+
+use crate::main_loop::USE_FINALIZATION;
 
 #[derive(Clone, Copy)]
 pub struct CheckedNonces {
@@ -37,7 +38,7 @@ pub async fn check_for_events(
 ) -> Result<CheckedNonces, GravityError> {
     let our_cosmos_address = our_private_key.to_address(&contact.get_prefix()).unwrap();
 
-    let ending_block = if USE_FINALIZATION {
+    let ending_block = if *USE_FINALIZATION {
         // get this first in case inbetween the calls is a block boundary
         // don't accidentally use this variable elswhere
         let unsafe_latest_block = get_latest_block_number_with_retry(web3).await;

--- a/orchestrator/test_runner/src/main.rs
+++ b/orchestrator/test_runner/src/main.rs
@@ -16,12 +16,13 @@ use gravity_utils::{
     get_block_delay, get_expected_block_delay,
     get_with_retry::get_net_version_with_retry,
     u64_array_bigints, TEST_DEFAULT_ETH_NODE_ENDPOINT, TEST_DEFAULT_MINER_KEY, TEST_ETH_CHAIN_ID,
-    TEST_GAS_LIMIT, TEST_RUN_BLOCK_STIMULATOR, USE_FINALIZATION,
+    TEST_GAS_LIMIT, TEST_RUN_BLOCK_STIMULATOR,
 };
 use happy_path::happy_path_test;
 use happy_path_v2::happy_path_test_v2;
 use lazy_static::lazy_static;
 use orch_keys::orch_keys;
+use orchestrator::main_loop::USE_FINALIZATION;
 use relay_market::relay_market_test;
 use remote_stress_test::remote_stress_test;
 use transaction_stress_test::transaction_stress_test;
@@ -158,7 +159,7 @@ pub async fn main() {
     if net_version != TEST_ETH_CHAIN_ID {
         warn!("Chain ID is not equal to TEST_ETH_CHAIN_ID");
     }
-    if USE_FINALIZATION {
+    if *USE_FINALIZATION {
         info!(
             "Using finalization with expected minimum block delay {}",
             expected_block_delay

--- a/tests/assets/ETHGenesis.json
+++ b/tests/assets/ETHGenesis.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "chainId": 15,
+    "chainId": 1337,
     "homesteadBlock": 0,
     "eip150Block": 0,
     "eip155Block": 0,

--- a/tests/container-scripts/all-up-test-internal.sh
+++ b/tests/container-scripts/all-up-test-internal.sh
@@ -44,7 +44,7 @@ fi
 # running the test runner only to deploy the ethereum contracts
 # note that variables like GRAVITY_ADDRESS affect the binary
 pushd /gravity/orchestrator/test_runner
-DEPLOY_CONTRACTS=1 RUST_BACKTRACE=full RUST_LOG="INFO,relayer=DEBUG,orchestrator=DEBUG" PATH=$PATH:$HOME/.cargo/bin $RUN_ARGS
+USE_FINALIZATION=false DEPLOY_CONTRACTS=1 RUST_BACKTRACE=full RUST_LOG="INFO,relayer=DEBUG,orchestrator=DEBUG" PATH=$PATH:$HOME/.cargo/bin $RUN_ARGS
 
 # runs the test runner for real
 bash /gravity/tests/container-scripts/integration-tests.sh $TEST_TYPE

--- a/tests/container-scripts/integration-tests.sh
+++ b/tests/container-scripts/integration-tests.sh
@@ -22,4 +22,4 @@ else
     RUN_ARGS=/gravity/tests/dockerfile/test-runner
 fi
 
-RUST_BACKTRACE=full TEST_TYPE=$TEST_TYPE RUST_LOG=INFO PATH=$PATH:$HOME/.cargo/bin $RUN_ARGS
+USE_FINALIZATION=false RUST_BACKTRACE=full TEST_TYPE=$TEST_TYPE RUST_LOG=INFO PATH=$PATH:$HOME/.cargo/bin $RUN_ARGS

--- a/tests/container-scripts/reload-code.sh
+++ b/tests/container-scripts/reload-code.sh
@@ -22,7 +22,7 @@ tests/container-scripts/run-testnet.sh $NODES $TEST_TYPE $ALCHEMY_ID
 
 # deploy the ethereum contracts
 pushd /gravity/orchestrator/test_runner
-DEPLOY_CONTRACTS=1 RUST_BACKTRACE=full TEST_TYPE=$TEST_TYPE NO_GAS_OPT=1 RUST_LOG="INFO,relayer=DEBUG,orchestrator=DEBUG" PATH=$PATH:$HOME/.cargo/bin cargo run --release --bin test-runner
+USE_FINALIZATION=false DEPLOY_CONTRACTS=1 RUST_BACKTRACE=full TEST_TYPE=$TEST_TYPE NO_GAS_OPT=1 RUST_LOG="INFO,relayer=DEBUG,orchestrator=DEBUG" PATH=$PATH:$HOME/.cargo/bin cargo run --release --bin test-runner
 
 # This keeps the script open to prevent Docker from stopping the container
 # immediately if the nodes are killed by a different process

--- a/tests/container-scripts/remote-test-for-ci.sh
+++ b/tests/container-scripts/remote-test-for-ci.sh
@@ -22,6 +22,6 @@ sleep 10
 
 # predeploy Gravity contract
 pushd /gravity/orchestrator/test_runner
-DEPLOY_CONTRACTS=1 RUST_BACKTRACE=full RUST_LOG="INFO,relayer=DEBUG,orchestrator=DEBUG" PATH=$PATH:$HOME/.cargo/bin $RUN_ARGS
+USE_FINALIZATION=false DEPLOY_CONTRACTS=1 RUST_BACKTRACE=full RUST_LOG="INFO,relayer=DEBUG,orchestrator=DEBUG" PATH=$PATH:$HOME/.cargo/bin $RUN_ARGS
 
 GRAVITY_ADDRESS=$(cat /contracts | sed -n -e 's/^Gravity deployed at Address -  //p') COSMOS_NODE_GRPC=http://localhost:9090 COSMOS_NODE_ABCI=http://localhost:26657 ETH_NODE=http://localhost:8545 bash /gravity/tests/container-scripts/all-up-test-internal.sh REMOTE_STRESS

--- a/tests/container-scripts/run-eth.sh
+++ b/tests/container-scripts/run-eth.sh
@@ -36,12 +36,12 @@ else
     # init the genesis block
     geth --identity "GravityTestnet" \
     --nodiscover \
-    --networkid 15 init /gravity/tests/assets/ETHGenesis.json
+    --networkid 1337 init /gravity/tests/assets/ETHGenesis.json
 
     # etherbase is where rewards get sent
     # private key for this address is 0xb1bab011e03a9862664706fc3bbaa1b16651528e5f0e7fbfcbfdd8be302a13e7
     geth --identity "GravityTestnet" --nodiscover \
-    --networkid 15 \
+    --networkid 1337 \
     --mine \
     --http \
     --http.addr="0.0.0.0" \


### PR DESCRIPTION
This will be the same as the v0.1.0eth2 production bridge except that `USE_FINALIZATION` can be configured with environment variable. It is true by default and can only be disabled with an explicit `USE_FINALIZATION=false` var